### PR TITLE
fix(tests,#7270): rebase Oobabooga WebSocketTestServer fix onto d72c1f1 (NRE tip) — unblock CoursIA #7271

### DIFF
--- a/dotnet/src/Connectors/Connectors.UnitTests/WebSocketTestServer.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/WebSocketTestServer.cs
@@ -66,7 +66,22 @@ internal class WebSocketTestServer : IDisposable
     {
         while (!this._mainCancellationTokenSource.IsCancellationRequested)
         {
-            var context = await this._httpListener.GetContextAsync().ConfigureAwait(false);
+            HttpListenerContext context;
+            try
+            {
+                context = await this._httpListener.GetContextAsync().ConfigureAwait(false);
+            }
+            catch (HttpListenerException) when (!this._serverIsRunning)
+            {
+                // Listener was stopped during shutdown (DisposeAsync stops it before
+                // awaiting this task). The blocking accept is unblocked; exit the loop.
+                break;
+            }
+            catch (ObjectDisposedException) when (!this._serverIsRunning)
+            {
+                // Listener was closed during shutdown; exit the accept loop.
+                break;
+            }
 
             if (this._serverIsRunning)
             {
@@ -206,9 +221,18 @@ internal class WebSocketTestServer : IDisposable
         {
             this._serverIsRunning = false;
             await this.CloseAllSocketsAsync(); // Close all sockets before finishing the tasks
-            await Task.WhenAll(this._runningTasks).ConfigureAwait(false);
+
+            // Stop the listener and cancel BEFORE awaiting the running tasks. GetContextAsync
+            // (in HandleRequestsAsync) has no CancellationToken overload and only unblocks when
+            // the listener is stopped; awaiting _runningTasks first deadlocks it, and delays
+            // releasing the HttpListener prefix. That delay causes "Failed to listen on prefix
+            // ... because it conflicts with an existing registration" failures when tests run
+            // in parallel (they share the fixed StreamingPort 2345). See #7270.
+            this._httpListener.Stop();
             this._socketCancellationTokenSource.Cancel();
             this._mainCancellationTokenSource.Cancel();
+
+            await Task.WhenAll(this._runningTasks).ConfigureAwait(false);
         }
         catch (OperationCanceledException exception)
         {
@@ -216,7 +240,6 @@ internal class WebSocketTestServer : IDisposable
         }
         finally
         {
-            this._httpListener.Stop();
             this._httpListener.Close();
             this._socketCancellationTokenSource.Dispose();
             this._mainCancellationTokenSource.Dispose();


### PR DESCRIPTION
## Summary

Rebase of the Oobabooga `WebSocketTestServer` prefix-conflict fix (#7270) **onto the current `upgrade-sk` tip `d72c1f1`** (the ExtensionData NRE null-guard from #7228). Resolves the submodule-pointer conflict that made CoursIA PR [#7271](https://github.com/jsboige/CoursIA/pull/7271) `CONFLICTING` after `c6033cf26` (#7228) landed on `main`.

## Why this rebase

CoursIA PR #7271 recorded the Oobabooga fix as submodule pointer `60bb63d7 → d82a8393`. The fix `d82a8393` was built on `60bb63d75` (the pre-#7228 submodule tip). PR #7228 (`c6033cf26`) then advanced the CoursIA `main` submodule pointer `60bb63d7 → d72c1f1` (NRE fix, built on `a02eb23`). Since `d82a8393` and `d72c1f1` are siblings (neither descends from the other), merging #7271 onto the new `main` produces a submodule conflict.

This PR cherry-picks the single-file Oobabooga fix (`WebSocketTestServer.cs`, +26/−3) onto `d72c1f1`, producing `8bdc3467` — a commit that descends from both. The CoursIA #7271 branch then rebases cleanly (pointer `d72c1f1 → 8bdc3467`).

## The two fixes are disjoint (no interaction possible)

| Fix | File touched | Commit |
|-----|--------------|--------|
| NRE null-guard (#7228) | `MultiCompletionRequestSettings.cs` (ctor + 3 foreach guards) | `d72c1f1` |
| Oobabooga prefix-conflict (#7270) | `WebSocketTestServer.cs` (DisposeAsync reorder + GetContextAsync guard) | `d82a8393` → cherry-picked as `8bdc346` |

Different files, different namespaces (`MultiConnector` vs `Oobabooga`/`UnitTests`), no shared code. The cherry-pick applied with **zero conflict** — the +26/−3 diff is byte-identical to the original `d82a8393` commit.

## Acceptance — structural proof (build + disjoint files + byte-identical patch)

- [x] `dotnet build Connectors.UnitTests.csproj -c Release` = **0 errors** (28 warnings, preexisting).
- [x] **Disjoint files (structurally impossible to interact)**: the NRE fix `d72c1f1` touches `MultiCompletionRequestSettings.cs` + `PromptSignature.cs`; the Oobabooga fix `8bdc346` touches only `WebSocketTestServer.cs`. **Intersection = empty** (verified `git show --name-only` on both).
- [x] **Byte-identical patched content**: `git diff d82a8393..8bdc346 -- WebSocketTestServer.cs` = empty — the rebased `WebSocketTestServer.cs` is byte-for-byte the same file as the standalone fix `d82a8393` (which was verified **22/22 Oobabooga.Completion PASS, 0 regression** in c.495, #7271). A cherry-pick of an identical single-file patch onto a disjoint-file parent cannot change the patched file's behaviour.
- [ ] **End-to-end `dotnet test` re-run on the rebased commit was NOT completed** — the Connectors.UnitTests test-discovery on this machine is pathologically slow (>10 min, testhost accumulating CPU without finishing for the `~Oobabooga.Completion` filter). Build SUCCESS + disjoint-files + byte-identical-patch + the proven c.495 result on the identical file together constitute the verification; a full re-test would be belt-and-suspenders but could not be obtained in-window. Reviewer (ai-01) is welcome to re-run on a faster env.

## History (linear)

```
a02eb23 fix(multi-connector): await ProcessTextCompletionResultsAsync (streaming CS4014)
   ↓
d72c1f1 fix(multi-connector): null-guard ExtensionData (SK 1.78 NRE)   [#7228]
   ↓
8bdc346 fix(tests,#7270): Oobabooga WebSocketTestServer prefix conflict  [this PR]
```

Closes nothing on its own — this submodule PR exists so CoursIA #7271 can rebase cleanly onto `main` and merge (it carries `Closes #7270`).

See #7270 (Oobabooga tracker), CoursIA #7271 (parent pointer-bump PR, CONFLICTING until this lands).
